### PR TITLE
This PR adds a cross-platform version of the `matrix_mode` tool

### DIFF
--- a/tools/matrix.py
+++ b/tools/matrix.py
@@ -9,7 +9,10 @@ import shutil
 def matrix_mode() -> str:
     """
     Opens a new terminal window and runs the cmatrix command to enter 'Matrix Mode'.
-    On Windows, simulates Matrix Mode using a Python script in a new console.
+    Use this tool when the user says something like:
+    - "Enter matrix mode"
+    - "Activate matrix mode"
+    - "Go into matrix mode"
     """
     system = platform.system()
 
@@ -31,18 +34,29 @@ def matrix_mode() -> str:
             return "Matrix mode has been activated, sir!"
 
         elif system == "Windows":
-            # Simulated Matrix Mode using Python
-            matrix_script = '''
+            python_script = '''
 import random
 import time
 import os
+import sys
 
 os.system("color 0A")  # Green text on black background
-chars = "01ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!@#$%^&*"
-width = 80
-height = 25
+chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!@#$%^&*"
+
+def get_terminal_size():
+    try:
+        import shutil
+        return shutil.get_terminal_size()
+    except:
+        return (80, 25)
+
+width, height = get_terminal_size()
+width = min(width, 120)
+height = min(height, 30)
+
 drops = [random.randint(0, height) for _ in range(width)]
 
+print("\\033[32m")
 print("Welcome to the Matrix. Press Ctrl+C to exit...")
 time.sleep(2)
 
@@ -60,12 +74,12 @@ try:
             print("".join(row))
         time.sleep(0.1)
 except KeyboardInterrupt:
-    print("\\nExiting Matrix...")
+    print("\\n\\033[32mExiting Matrix...\\033[0m")
     time.sleep(1)
 '''
 
             with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False, encoding='utf-8') as f:
-                f.write(matrix_script)
+                f.write(python_script)
                 script_path = f.name
 
             subprocess.Popen([sys.executable, script_path], creationflags=subprocess.CREATE_NEW_CONSOLE)
@@ -75,3 +89,4 @@ except KeyboardInterrupt:
             return f"Matrix mode is not supported on {system}."
     except Exception as e:
         return f"Failed to activate matrix mode: {str(e)}"
+

--- a/tools/matrix.py
+++ b/tools/matrix.py
@@ -1,32 +1,75 @@
 from langchain.tools import tool
 import subprocess
 import platform
+import tempfile
+import sys
+import shutil
 
 @tool("matrix_mode", return_direct=True)
 def matrix_mode() -> str:
     """
     Opens a new terminal window and runs the cmatrix command to enter 'Matrix Mode'.
-    Use this tool when the user says something like:
-    - "Enter matrix mode"
-    - "Activate matrix mode"
-    - "Go into matrix mode"
+    On Windows, simulates Matrix Mode using a Python script in a new console.
     """
     system = platform.system()
 
     try:
         if system == "Linux":
-            # Replace 'gnome-terminal' if you're using xterm, konsole, etc.
+            if shutil.which("cmatrix") is None:
+                return "Matrix mode requires 'cmatrix'. Please install it using your package manager."
             subprocess.Popen(["gnome-terminal", "--", "cmatrix"])
-            return "Matrix mode activated! Enjoy the rain neo."
+            return "Matrix mode activated! Enjoy the rain, Neo."
 
         elif system == "Darwin":
-            # macOS version
+            if shutil.which("cmatrix") is None:
+                return "Matrix mode requires 'cmatrix'. You can install it via Homebrew: brew install cmatrix"
             subprocess.Popen([
                 "osascript", "-e",
                 'tell application "Terminal" to do script "cmatrix"',
                 "-e", 'tell application "Terminal" to activate'
             ])
-            return "Matrix mode has been activated sir!"
+            return "Matrix mode has been activated, sir!"
+
+        elif system == "Windows":
+            # Simulated Matrix Mode using Python
+            matrix_script = '''
+import random
+import time
+import os
+
+os.system("color 0A")  # Green text on black background
+chars = "01ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!@#$%^&*"
+width = 80
+height = 25
+drops = [random.randint(0, height) for _ in range(width)]
+
+print("Welcome to the Matrix. Press Ctrl+C to exit...")
+time.sleep(2)
+
+try:
+    while True:
+        os.system("cls")
+        screen = [[" " for _ in range(width)] for _ in range(height)]
+        for i in range(width):
+            if drops[i] < height:
+                screen[drops[i]][i] = random.choice(chars)
+            drops[i] += 1
+            if drops[i] > height and random.random() > 0.95:
+                drops[i] = 0
+        for row in screen:
+            print("".join(row))
+        time.sleep(0.1)
+except KeyboardInterrupt:
+    print("\\nExiting Matrix...")
+    time.sleep(1)
+'''
+
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False, encoding='utf-8') as f:
+                f.write(matrix_script)
+                script_path = f.name
+
+            subprocess.Popen([sys.executable, script_path], creationflags=subprocess.CREATE_NEW_CONSOLE)
+            return "Matrix mode activated! Welcome to the Matrix, Neo. Press Ctrl+C to exit."
 
         else:
             return f"Matrix mode is not supported on {system}."


### PR DESCRIPTION
enabling support for Windows alongside existing Linux and macOS logic.

### Changes

- Detects OS using `platform.system()`
- Adds a simulated Matrix Mode for Windows using a Python script
- Includes fallback messaging for unsupported platforms
- Adds dependency checks for `cmatrix` on Unix systems

### Motivation

The original `matrix_mode` only supports Unix-like systems. This enhancement allows Windows users to enjoy a basic version of the Matrix Mode without needing external dependencies.

### Notes

- Windows version uses ANSI codes and console manipulation to simulate matrix rain
- Tested on Windows 11 with Python 3.10+
- No changes to existing Unix behavior